### PR TITLE
Adapt to Node API change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+###
+- Adapt to Node API changes in pytest-5.4 (Fixes #11)
+
 ## [0.2.2] - 2019-05-24
 ###
 - Add hack for handling mock style objects


### PR DESCRIPTION
The Node API was changed in pytest 5.4 in
https://github.com/pytest-dev/pytest/pull/5975.

This commit adds support for the new API but maintains backwards
compatiblity.

Closes: #11