### PR TITLE
Skipif testoutput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ###
 - Adapt to Node API changes in pytest-5.4 (Fixes #11)
 - Add support for python 3.8 (Fixes #15)
+- Add support for skipif option in testoutput directive (Fixes #17)
 
 ## [0.2.2] - 2019-05-24
 ###

--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,7 @@ Features
 * support for parsing global optionflags (``doctest_optionflags``) from
   ``pytest.ini``
 * support for ``:options:`` in ``testoutput``
+* support for ``:skipif:`` in ``testoutput``
 
 
 Requirements

--- a/pytest_sphinx.py
+++ b/pytest_sphinx.py
@@ -5,7 +5,6 @@ https://github.com/sphinx-doc/sphinx/blob/master/sphinx/ext/doctest.py
 
 * TODO
 ** CLEANUP: use the sphinx directive parser from the sphinx project
-** support for :options: in testoutput (see sphinx-doc)
 """
 
 import doctest

--- a/tests/test_text_files.py
+++ b/tests/test_text_files.py
@@ -182,4 +182,4 @@ def test_skipif_non_builtin(testdir):
     )
 
     result = testdir.runpytest("--doctest-modules")
-    result.stdout.fnmatch_lines(["*NameError: name 'pd' is not defined"])
+    result.stdout.fnmatch_lines(["*NameError:*name 'pd' is not defined"])

--- a/tests/test_text_files.py
+++ b/tests/test_text_files.py
@@ -165,3 +165,21 @@ def test_no_ellipsis_in_global_optionflags(testdir):
     result.stdout.fnmatch_lines(
         ["Expected:", "*ab...gh", "Got:", "*abcdefgh", "*=== 1 failed in *"]
     )
+
+
+def test_skipif_non_builtin(testdir):
+    testdir.maketxtfile(
+        test_something="""
+        .. testcode::
+
+            print('abcdefgh')
+
+        .. testoutput::
+            :skipif: pd is not None
+
+            NOT EVALUATED
+    """
+    )
+
+    result = testdir.runpytest("--doctest-modules")
+    result.stdout.fnmatch_lines(["*NameError: name 'pd' is not defined"])


### PR DESCRIPTION
Support for :skipif: in testoutput directive
    
The value of the skipif option is evaluated as a Python expression. If
the result is a true-ish value, the directive is omitted from the test
run just as if it wasn’t present in the file at all.
    
As said in the subject-line, currently this is only implemented for the
testoutput directive.
    
Closes: #17
