### PR TITLE
(WIP) Myst parser: `.md` + `{eval-rst}` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - internal: Switch from setup.py to a PEP-621 pyproject.toml, from
    [Tony Narlock](https://www.git-pull.com).
 
+- Support for markdown `.md` files and `{eval-rst}` myst-parser directives, from 
+  [Tony Narlock](https://www.git-pull.com) (re: #30, via #31).
+
 ## [0.4.0] - 2022-03-30
 ###
  - Drop python2.7 (Fixes #14)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ lint = [
     "black",
     "mypy"
 ]
+myst-parser = [
+    "myst-parser"
+]
 
 [project.urls]
 homepage = "https://github.com/thisch/pytest-sphinx"

--- a/src/pytest_sphinx.py
+++ b/src/pytest_sphinx.py
@@ -97,6 +97,7 @@ _OPTION_SKIPIF_RE = re.compile(r':skipif:\s*([^\n\'"]*)$')
 
 _DIRECTIVE_RE = re.compile(
     r"""
+    (?P<myst_directive>`{3}{eval-rst}\n?)?
     \s*\.\.\s
     (?P<directive>(testcode|testoutput|testsetup|testcleanup|doctest))
     ::\s*

--- a/src/pytest_sphinx.py
+++ b/src/pytest_sphinx.py
@@ -79,7 +79,7 @@ GlobDict = Dict[str, Any]
 
 
 def _is_doctest(config: Config, path: Path, parent: Union[Session, Package]) -> bool:
-    if path.suffix in (".txt", ".rst") and parent.session.isinitpath(path):
+    if path.suffix in (".txt", ".rst", ".md") and parent.session.isinitpath(path):
         return True
     globs = config.getoption("doctestglob") or ["test*.txt"]
     assert isinstance(globs, list)

--- a/tests/test_doc2test.py
+++ b/tests/test_doc2test.py
@@ -87,9 +87,10 @@ def test_indented() -> None:
     assert example.lineno == 7
 
 
-def test_cartopy() -> None:
+@pytest.mark.parametrize("file_type", ["rst", "md"])
+def test_cartopy(file_type: str) -> None:
     rstpath = os.path.join(
-        os.path.dirname(__file__), "testdata", "using_the_shapereader.rst"
+        os.path.dirname(__file__), "testdata", f"using_the_shapereader.{file_type}"
     )
     with open(rstpath) as fh:
         sections = get_sections(fh.read())

--- a/tests/test_doc2test.py
+++ b/tests/test_doc2test.py
@@ -8,9 +8,10 @@ from pytest_sphinx import docstring2examples
 from pytest_sphinx import get_sections
 
 
-@pytest.mark.parametrize("in_between_content", ["", "\nsome text\nmore text"])
-def test_simple(in_between_content: str) -> None:
-    doc = """
+@pytest.mark.parametrize(
+    "doc",
+    [
+        """
 .. testcode::
 
     import pprint
@@ -20,9 +21,27 @@ def test_simple(in_between_content: str) -> None:
 
     {{'3': 4,
      '5': 6}}
-""".format(
-        in_between_content
-    )
+""",
+        """
+```{{eval-rst}}
+.. testcode::
+
+    import pprint
+    pprint.pprint({{'3': 4, '5': 6}})
+```
+{}
+```{{eval-rst}}
+.. testoutput::
+
+    {{'3': 4,
+     '5': 6}}
+```
+""",
+    ],
+)
+@pytest.mark.parametrize("in_between_content", ["", "\nsome text\nmore text"])
+def test_simple(doc: str, in_between_content: str) -> None:
+    doc = doc.format(in_between_content)
 
     examples = docstring2examples(doc)
     assert len(examples) == 1

--- a/tests/test_doc2test.py
+++ b/tests/test_doc2test.py
@@ -82,9 +82,11 @@ def test_with_options(doc: str) -> None:
     assert example.lineno == 5
 
 
-def test_indented() -> None:
-    doc = textwrap.dedent(
-        """
+@pytest.mark.parametrize(
+    "doc",
+    [
+        textwrap.dedent(
+            """
     Examples:
         some text
 
@@ -96,8 +98,29 @@ def test_indented() -> None:
 
             Banana
     """
-    )
+        ),
+        textwrap.dedent(
+            """
+    Examples:
+        some text
 
+        ```{eval-rst}
+        .. testcode::
+
+            print("Banana")
+        ```
+
+        ```{eval-rst}
+        .. testoutput::
+
+            Banana
+        ```
+    """
+        ),
+    ],
+    ids=["rst", "myst-eval-rst"],
+)
+def test_indented(doc: str) -> None:
     examples = docstring2examples(doc)
     assert len(examples) == 1
     example = examples[0]

--- a/tests/test_doc2test.py
+++ b/tests/test_doc2test.py
@@ -34,8 +34,10 @@ def test_simple(in_between_content: str) -> None:
     assert example.lineno == 5
 
 
-def test_with_options() -> None:
-    doc = """
+@pytest.mark.parametrize(
+    "doc",
+    [
+        """
 .. testcode::
 
     import pprint
@@ -45,8 +47,27 @@ def test_with_options() -> None:
     :options: +NORMALIZE_WHITESPACE, +ELLIPSIS
 
     {'3': 4,
-     '5': 6}"""
+     '5': 6}""",
+        """
+```{eval-rst}
+.. testcode::
 
+    import pprint
+    pprint.pprint({'3': 4, '5': 6})
+```
+
+```{eval-rst}
+.. testoutput::
+    :options: +NORMALIZE_WHITESPACE, +ELLIPSIS
+
+    {'3': 4,
+     '5': 6}
+```
+""",
+    ],
+    ids=["rst", "myst-eval-rst"],
+)
+def test_with_options(doc: str) -> None:
     examples = docstring2examples(doc)
     assert len(examples) == 1
     example = examples[0]

--- a/tests/test_sphinx_doctest.py
+++ b/tests/test_sphinx_doctest.py
@@ -5,6 +5,8 @@ import subprocess
 import textwrap
 from pathlib import Path
 from typing import Iterator
+from typing import List
+from typing import Optional
 from typing import Union
 
 import pytest
@@ -37,13 +39,20 @@ class SphinxDoctestRunner:
         )
 
     def __call__(
-        self, rst_file_content: str, must_raise: bool = False, sphinxopts: None = None
-    ) -> str:
+        self,
+        file_content: str,
+        must_raise: bool = False,
+        file_type: str = "rst",
+        sphinxopts: Optional[List[str]] = None,
+    ):
         index_rst = self.tmp_path / "source" / "index.rst"
-        rst_file_content = textwrap.dedent(rst_file_content)
-        index_rst.write_text(rst_file_content, encoding="utf-8")
+        index_file = self.tmp_path / "source" / f"index.{file_type}"
+        file_content = textwrap.dedent(file_content)
+        index_file.write_text(file_content, encoding="utf-8")
+        if file_type == "md":  # Delete sphinx-quickstart's .rst file
+            index_rst.unlink()
         logger.info("CWD: %s", os.getcwd())
-        logger.info("content of index.rst:\n%s", rst_file_content)
+        logger.info(f"content of index.{file_type}:\n%s", file_content)
 
         cmd = ["sphinx-build", "-M", "doctest", "source", ""]
         if sphinxopts is not None:
@@ -68,7 +77,9 @@ class SphinxDoctestRunner:
 
 
 @pytest.fixture
-def sphinx_tester(tmpdir: LocalPath) -> Iterator[SphinxDoctestRunner]:
+def sphinx_tester(
+    tmpdir: LocalPath, request: pytest.FixtureRequest
+) -> Iterator[SphinxDoctestRunner]:
     with tmpdir.as_cwd():
         yield SphinxDoctestRunner(tmpdir)
 
@@ -140,7 +151,6 @@ class TestDirectives:
                >>> print("msg from testcode directive")
                msg from testcode directive
             """
-
         sphinx_output = sphinx_tester(code)
         assert "1 items passed all tests" in sphinx_output
 

--- a/tests/test_sphinx_doctest.py
+++ b/tests/test_sphinx_doctest.py
@@ -46,8 +46,11 @@ class SphinxDoctestRunner:
         logger.info("content of index.rst:\n%s", rst_file_content)
 
         cmd = ["sphinx-build", "-M", "doctest", "source", ""]
-        if sphinxopts:
-            cmd.append(sphinxopts)
+        if sphinxopts is not None:
+            if isinstance(sphinxopts, list):
+                cmd.extend(sphinxopts)
+            else:
+                cmd.append(sphinxopts)
 
         def to_str(subprocess_output: Union[str, bytes]) -> str:
             if isinstance(subprocess_output, bytes):

--- a/tests/testdata/using_the_shapereader.md
+++ b/tests/testdata/using_the_shapereader.md
@@ -2,12 +2,12 @@
 
 # Using the cartopy shapereader
 
-Cartopy provides an object oriented shapefile reader based on top of the
-[pyshp] module to provide easy, programmatic, access to standard vector datasets.
+Cartopy provides an object oriented shapefile reader based on top of the [pyshp] module to provide
+easy, programmatic, access to standard vector datasets.
 
-Cartopy's wrapping of pyshp has the benefit of being pure python, and is therefore
-easy to install and extremely portable. However, for heavy duty shapefile I/O [Fiona] and
-[GeoPandas] are highly recommended.
+Cartopy's wrapping of pyshp has the benefit of being pure python, and is therefore easy to install
+and extremely portable. However, for heavy duty shapefile I/O [Fiona] and [GeoPandas] are highly
+recommended.
 
 ```{eval-rst}
 .. currentmodule:: cartopy.io.shapereader
@@ -29,11 +29,11 @@ easy to install and extremely portable. However, for heavy duty shapefile I/O [F
 ## Helper functions for shapefile acquisition
 
 Cartopy provides an interface for access to frequently used data such as the
-[GSHHS](https://www.ngdc.noaa.gov/mgg/shorelines/gshhs.html) dataset and from
-the [NaturalEarthData](http://www.naturalearthdata.com/) website.
-These interfaces allow the user to define the data programmatically, and if the data does not exist
-on disk, it will be retrieved from the appropriate source (normally by
-downloading the data from the internet). Currently the interfaces available are:
+[GSHHS](https://www.ngdc.noaa.gov/mgg/shorelines/gshhs.html) dataset and from the
+[NaturalEarthData](http://www.naturalearthdata.com/) website. These interfaces allow the user to
+define the data programmatically, and if the data does not exist on disk, it will be retrieved from
+the appropriate source (normally by downloading the data from the internet). Currently the
+interfaces available are:
 
 ```{eval-rst}
 .. autofunction:: natural_earth
@@ -47,8 +47,8 @@ downloading the data from the internet). Currently the interfaces available are:
 ## Using the shapereader
 
 We can acquire the countries dataset from Natural Earth found at
-<http://www.naturalearthdata.com/downloads/110m-cultural-vectors/110m-admin-0-countries/>
-by using the {func}`natural_earth` function:
+<http://www.naturalearthdata.com/downloads/110m-cultural-vectors/110m-admin-0-countries/> by using
+the {func}`natural_earth` function:
 
 ```{eval-rst}
 .. testcode:: countries
@@ -61,8 +61,7 @@ by using the {func}`natural_earth` function:
 
 ```
 
-From here, we can make use of the {class}`Reader` to get the first country
-in the shapefile:
+From here, we can make use of the {class}`Reader` to get the first country in the shapefile:
 
 ```{eval-rst}
 .. testcode:: countries
@@ -72,8 +71,7 @@ in the shapefile:
     country = next(countries)
 ```
 
-We can get the country's attributes dictionary with the
-{data}`Record.attributes` attribute:
+We can get the country's attributes dictionary with the {data}`Record.attributes` attribute:
 
 ```{eval-rst}
 .. doctest:: countries
@@ -112,98 +110,99 @@ Which we can print with
 
 **Exercises**:
 
-> - **SHP.1**: Repeat the last example to show the 4 most populated African countries in to the shapefile.
->
->   Hint: Look at the possible attributes to find out which continent a country belongs.
->
->   Answer:
->
->   > ```{eval-rst}
->   > .. testcode:: countries
->   >     :hide:
->   >
->   >     reader = shpreader.Reader(shpfilename)
->   >
->   >     # define a function which can return the population of a given country
->   >     population = lambda country: country.attributes['pop_est']
->   >
->   >     # sort the countries by population
->   >     countries_by_pop = sorted(reader.records(), key=population)
->   >
->   >     # define a function which can return whether a country belongs to Africa
->   >     is_african = lambda country: country.attributes['continent'] == 'Africa'
->   >
->   >     # remove non-African countries
->   >     african_countries = filter(is_african, countries_by_pop)
->   >
->   >     print ', '.join([country.attributes['name_long']
->   >                      for country in african_countries[-4:]])
->   > ```
->   >
->   > ```{eval-rst}
->   > .. testoutput:: countries
->   >
->   >     Democratic Republic of the Congo, Egypt, Ethiopia, Nigeria
->   > ```
->
-> - **SHP.2**: Using the countries shapefile, find the most populated country grouped
->   by the first letter of the "name_long".
->
->   Hint: {func}`itertools.groupby` can help with the grouping.
->
->   Answer:
->
->   ```{eval-rst}
->   .. testcode:: countries
->        :hide:
->
->        import itertools
->
->        reader = shpreader.Reader(shpfilename)
->
->        # define a function which returns the first letter of a country's name
->        first_letter = lambda country: country.attributes['name_long'][0]
->        # define a function which returns the population of a country
->        population = lambda country: country.attributes['pop_est']
->
->        # sort the countries so that the groups come out alphabetically
->        countries = sorted(reader.records(), key=first_letter)
->
->        # group the countries by first letter
->        for letter, countries in itertools.groupby(countries, key=first_letter):
->            # print the letter and least populated country
->            print letter, sorted(countries, key=population)[-1].attributes['name_long']
->   ```
->
->   ```{eval-rst}
->   .. testoutput:: countries
->
->            A Argentina
->            B Brazil
->            C China
->            D Democratic Republic of the Congo
->            E Ethiopia
->            F France
->            G Germany
->            H Hungary
->            I India
->            J Japan
->            K Kenya
->            L Lao PDR
->            M Mexico
->            N Nigeria
->            O Oman
->            P Pakistan
->            Q Qatar
->            R Russian Federation
->            S South Africa
->            T Turkey
->            U United States
->            V Vietnam
->            W Western Sahara
->            Y Yemen
->            Z Zimbabwe
->   ```
+- **SHP.1**: Repeat the last example to show the 4 most populated African countries in to the
+  shapefile.
+
+  Hint: Look at the possible attributes to find out which continent a country belongs.
+
+  Answer:
+
+  ```{eval-rst}
+  .. testcode:: countries
+      :hide:
+
+      reader = shpreader.Reader(shpfilename)
+
+      # define a function which can return the population of a given country
+      population = lambda country: country.attributes['pop_est']
+
+      # sort the countries by population
+      countries_by_pop = sorted(reader.records(), key=population)
+
+      # define a function which can return whether a country belongs to Africa
+      is_african = lambda country: country.attributes['continent'] == 'Africa'
+
+      # remove non-African countries
+      african_countries = filter(is_african, countries_by_pop)
+
+      print ', '.join([country.attributes['name_long']
+                       for country in african_countries[-4:]])
+  ```
+
+  ```{eval-rst}
+  .. testoutput:: countries
+
+      Democratic Republic of the Congo, Egypt, Ethiopia, Nigeria
+  ```
+
+- **SHP.2**: Using the countries shapefile, find the most populated country grouped by the first
+  letter of the "name_long".
+
+  Hint: {func}`itertools.groupby` can help with the grouping.
+
+  Answer:
+
+  ```{eval-rst}
+  .. testcode:: countries
+       :hide:
+
+       import itertools
+
+       reader = shpreader.Reader(shpfilename)
+
+       # define a function which returns the first letter of a country's name
+       first_letter = lambda country: country.attributes['name_long'][0]
+       # define a function which returns the population of a country
+       population = lambda country: country.attributes['pop_est']
+
+       # sort the countries so that the groups come out alphabetically
+       countries = sorted(reader.records(), key=first_letter)
+
+       # group the countries by first letter
+       for letter, countries in itertools.groupby(countries, key=first_letter):
+           # print the letter and least populated country
+           print letter, sorted(countries, key=population)[-1].attributes['name_long']
+  ```
+
+  ```{eval-rst}
+  .. testoutput:: countries
+
+           A Argentina
+           B Brazil
+           C China
+           D Democratic Republic of the Congo
+           E Ethiopia
+           F France
+           G Germany
+           H Hungary
+           I India
+           J Japan
+           K Kenya
+           L Lao PDR
+           M Mexico
+           N Nigeria
+           O Oman
+           P Pakistan
+           Q Qatar
+           R Russian Federation
+           S South Africa
+           T Turkey
+           U United States
+           V Vietnam
+           W Western Sahara
+           Y Yemen
+           Z Zimbabwe
+  ```
 
 [fiona]: http://toblerity.org/fiona/
 [geopandas]: http://geopandas.org/

--- a/tests/testdata/using_the_shapereader.md
+++ b/tests/testdata/using_the_shapereader.md
@@ -1,0 +1,210 @@
+(using-the-shapereader)=
+
+# Using the cartopy shapereader
+
+Cartopy provides an object oriented shapefile reader based on top of the
+[pyshp] module to provide easy, programmatic, access to standard vector datasets.
+
+Cartopy's wrapping of pyshp has the benefit of being pure python, and is therefore
+easy to install and extremely portable. However, for heavy duty shapefile I/O [Fiona] and
+[GeoPandas] are highly recommended.
+
+```{eval-rst}
+.. currentmodule:: cartopy.io.shapereader
+```
+
+```{eval-rst}
+.. autoclass:: Reader
+    :members:
+    :undoc-members:
+```
+
+```{eval-rst}
+.. autoclass:: Record
+    :members:
+    :undoc-members:
+
+```
+
+## Helper functions for shapefile acquisition
+
+Cartopy provides an interface for access to frequently used data such as the
+[GSHHS](https://www.ngdc.noaa.gov/mgg/shorelines/gshhs.html) dataset and from
+the [NaturalEarthData](http://www.naturalearthdata.com/) website.
+These interfaces allow the user to define the data programmatically, and if the data does not exist
+on disk, it will be retrieved from the appropriate source (normally by
+downloading the data from the internet). Currently the interfaces available are:
+
+```{eval-rst}
+.. autofunction:: natural_earth
+```
+
+```{eval-rst}
+.. autofunction:: gshhs
+
+```
+
+## Using the shapereader
+
+We can acquire the countries dataset from Natural Earth found at
+<http://www.naturalearthdata.com/downloads/110m-cultural-vectors/110m-admin-0-countries/>
+by using the {func}`natural_earth` function:
+
+```{eval-rst}
+.. testcode:: countries
+
+    import cartopy.io.shapereader as shpreader
+
+    shpfilename = shpreader.natural_earth(resolution='110m',
+                                          category='cultural',
+                                          name='admin_0_countries')
+
+```
+
+From here, we can make use of the {class}`Reader` to get the first country
+in the shapefile:
+
+```{eval-rst}
+.. testcode:: countries
+
+    reader = shpreader.Reader(shpfilename)
+    countries = reader.records()
+    country = next(countries)
+```
+
+We can get the country's attributes dictionary with the
+{data}`Record.attributes` attribute:
+
+```{eval-rst}
+.. doctest:: countries
+    :options: +ELLIPSIS
+
+    >>> print type(country.attributes)
+    <type 'dict'>
+    >>> print sorted(country.attributes.keys())
+    ['abbrev', ..., 'name_long', ... 'pop_est', ...]
+```
+
+We could now find the 5 least populated countries with:
+
+```{eval-rst}
+.. testcode:: countries
+
+    reader = shpreader.Reader(shpfilename)
+
+    # define a function which returns the population given the country
+    population = lambda country: country.attributes['pop_est']
+
+    # sort the countries by population and get the first 5
+    countries_by_pop = sorted(reader.records(), key=population)[:5]
+```
+
+Which we can print with
+
+```{eval-rst}
+.. doctest:: countries
+
+    >>> ', '.join([country.attributes['name_long']
+    ...            for country in countries_by_pop])
+    'Western Sahara, French Southern and Antarctic Lands, Falkland Islands, Antarctica, Greenland'
+
+```
+
+**Exercises**:
+
+> - **SHP.1**: Repeat the last example to show the 4 most populated African countries in to the shapefile.
+>
+>   Hint: Look at the possible attributes to find out which continent a country belongs.
+>
+>   Answer:
+>
+>   > ```{eval-rst}
+>   > .. testcode:: countries
+>   >     :hide:
+>   >
+>   >     reader = shpreader.Reader(shpfilename)
+>   >
+>   >     # define a function which can return the population of a given country
+>   >     population = lambda country: country.attributes['pop_est']
+>   >
+>   >     # sort the countries by population
+>   >     countries_by_pop = sorted(reader.records(), key=population)
+>   >
+>   >     # define a function which can return whether a country belongs to Africa
+>   >     is_african = lambda country: country.attributes['continent'] == 'Africa'
+>   >
+>   >     # remove non-African countries
+>   >     african_countries = filter(is_african, countries_by_pop)
+>   >
+>   >     print ', '.join([country.attributes['name_long']
+>   >                      for country in african_countries[-4:]])
+>   > ```
+>   >
+>   > ```{eval-rst}
+>   > .. testoutput:: countries
+>   >
+>   >     Democratic Republic of the Congo, Egypt, Ethiopia, Nigeria
+>   > ```
+>
+> - **SHP.2**: Using the countries shapefile, find the most populated country grouped
+>   by the first letter of the "name_long".
+>
+>   Hint: {func}`itertools.groupby` can help with the grouping.
+>
+>   Answer:
+>
+>   ```{eval-rst}
+>   .. testcode:: countries
+>        :hide:
+>
+>        import itertools
+>
+>        reader = shpreader.Reader(shpfilename)
+>
+>        # define a function which returns the first letter of a country's name
+>        first_letter = lambda country: country.attributes['name_long'][0]
+>        # define a function which returns the population of a country
+>        population = lambda country: country.attributes['pop_est']
+>
+>        # sort the countries so that the groups come out alphabetically
+>        countries = sorted(reader.records(), key=first_letter)
+>
+>        # group the countries by first letter
+>        for letter, countries in itertools.groupby(countries, key=first_letter):
+>            # print the letter and least populated country
+>            print letter, sorted(countries, key=population)[-1].attributes['name_long']
+>   ```
+>
+>   ```{eval-rst}
+>   .. testoutput:: countries
+>
+>            A Argentina
+>            B Brazil
+>            C China
+>            D Democratic Republic of the Congo
+>            E Ethiopia
+>            F France
+>            G Germany
+>            H Hungary
+>            I India
+>            J Japan
+>            K Kenya
+>            L Lao PDR
+>            M Mexico
+>            N Nigeria
+>            O Oman
+>            P Pakistan
+>            Q Qatar
+>            R Russian Federation
+>            S South Africa
+>            T Turkey
+>            U United States
+>            V Vietnam
+>            W Western Sahara
+>            Y Yemen
+>            Z Zimbabwe
+>   ```
+
+[fiona]: http://toblerity.org/fiona/
+[geopandas]: http://geopandas.org/
+[pyshp]: https://github.com/GeospatialPython/pyshp


### PR DESCRIPTION
re: #30

Naïve [`eval-rst`](https://myst-parser.readthedocs.io/en/latest/syntax/roles-and-directives.html#roles-directives:~:text=For%20special%20cases%2C%20MySt%20also%20offers%20the%20eval%2Drst%20directive.%20This%20will%20parse%20the%20content%20as%20ReStructuredText%3A) directive support.

- Support `.md`
- Adds `testdata/using_the_shapereader.md`
- Tests `using_the_shapereader.md` in `test_cartopy`
- Support for `{eval-rst}` and tests
- `_DIRECTIVE_RE` improvements - Use verbose, named expression for readability _(cherry-picked and rebased in via #33, #34)_