### PR TITLE
chore(.gitignore): Ignore virtualenv directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+.*env*
 build/
 develop-eggs/
 dist/


### PR DESCRIPTION
Will you accept this, (or any variation of this pattern)? 

This way contributors won't be prompted to stage `.venv`, `.env`, etc. virtual environment dirs.

[Here's what I've used](https://github.com/tmux-python/tmuxp/blob/f55d552/.gitignore#L14) on another project for a while