### PR TITLE
Revert "Make `SKIP` behave like `MOCK` (#3)"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pytest-sphinx"
-version = "0.5.1-fork"
+version = "0.5.1.dev"
 description = "Doctest plugin for pytest with support for Sphinx-specific doctest-directives"
 readme = "README.rst"
 requires-python = ">=3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pytest-sphinx"
-version = "0.5.0"
+version = "0.5.0-fork"
 description = "Doctest plugin for pytest with support for Sphinx-specific doctest-directives"
 readme = "README.rst"
 requires-python = ">=3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pytest-sphinx"
-version = "0.5.0-fork"
+version = "0.5.1-fork"
 description = "Doctest plugin for pytest with support for Sphinx-specific doctest-directives"
 readme = "README.rst"
 requires-python = ">=3.7"

--- a/src/pytest_sphinx.py
+++ b/src/pytest_sphinx.py
@@ -59,6 +59,8 @@ _DIRECTIVES_W_SKIPIF = (
     SphinxDoctestDirectives.DOCTEST,
 )
 
+_MOCK = doctest.register_optionflag("MOCK")
+
 
 def pytest_collect_file(
     file_path: Path, parent: Union[Session, Package]
@@ -436,7 +438,10 @@ class SphinxDocTestRunner(doctest.DebugRunner):
             # If the example executed without raising any exceptions,
             # verify its output.
             if exception is None:
-                if check(example.want, got, self.optionflags):
+                # If 'MOCK' is set, then don't check the output.
+                if self.optionflags & _MOCK:
+                    outcome = SUCCESS
+                elif check(example.want, got, self.optionflags):
                     outcome = SUCCESS
 
             # The example raised an exception:  check if it was expected.

--- a/src/pytest_sphinx.py
+++ b/src/pytest_sphinx.py
@@ -47,6 +47,11 @@ class SphinxDoctestDirectives(enum.Enum):
     DOCTEST = 5
 
 
+class DirectiveSyntax(enum.Enum):
+    RST = 1
+    MYST = 2
+
+
 _DIRECTIVES_W_OPTIONS = (
     SphinxDoctestDirectives.TESTOUTPUT,
     SphinxDoctestDirectives.DOCTEST,
@@ -81,7 +86,7 @@ GlobDict = Dict[str, Any]
 
 
 def _is_doctest(config: Config, path: Path, parent: Union[Session, Package]) -> bool:
-    if path.suffix in (".txt", ".rst") and parent.session.isinitpath(path):
+    if path.suffix in (".txt", ".rst", ".md") and parent.session.isinitpath(path):
         return True
     globs = config.getoption("doctestglob") or ["test*.txt"]
     assert isinstance(globs, list)
@@ -97,7 +102,7 @@ def _is_doctest(config: Config, path: Path, parent: Union[Session, Package]) -> 
 _OPTION_DIRECTIVE_RE = re.compile(r':options:\s*([^\n\'"]*)$')
 _OPTION_SKIPIF_RE = re.compile(r':skipif:\s*([^\n\'"]*)$')
 
-_DIRECTIVE_RE = re.compile(
+_RST_DIRECTIVE_RE = re.compile(
     r"""
     \s*\.\.\s
     (?P<directive>(testcode|testoutput|testsetup|testcleanup|doctest))
@@ -107,6 +112,28 @@ _DIRECTIVE_RE = re.compile(
     """,
     re.VERBOSE,
 )
+
+_MYST_DIRECTIVE_RE = re.compile(
+    r"""
+    \s*```
+    {(?P<directive>(testcode|testoutput|testsetup|testcleanup|doctest))}
+    \s*
+    (?P<argument>([^\n'"]*))
+    $
+    """,
+    re.VERBOSE,
+)
+
+_SYNTAX_TO_DIRECTIVE_RE = {
+    DirectiveSyntax.RST: _RST_DIRECTIVE_RE,
+    DirectiveSyntax.MYST: _MYST_DIRECTIVE_RE,
+}
+
+_FILE_EXTENSION_TO_SYNTAX = {
+    ".rst": DirectiveSyntax.RST,
+    ".md": DirectiveSyntax.MYST,
+    ".py": DirectiveSyntax.RST,
+}
 
 
 def _split_into_body_and_options(
@@ -224,7 +251,7 @@ class Section:
         self.options = options
 
 
-def get_sections(docstring: str) -> List[Union[Any, Section]]:
+def get_sections(docstring: str, syntax: DirectiveSyntax) -> List[Union[Any, Section]]:
     lines = textwrap.dedent(docstring).splitlines()
     sections = []
 
@@ -250,7 +277,7 @@ def get_sections(docstring: str) -> List[Union[Any, Section]]:
         except IndexError:
             break
 
-        match = _DIRECTIVE_RE.match(line)
+        match = _SYNTAX_TO_DIRECTIVE_RE[syntax].match(line)
         if match:
             group = match.groupdict()
             directive = getattr(SphinxDoctestDirectives, group["directive"].upper())
@@ -265,7 +292,11 @@ def get_sections(docstring: str) -> List[Union[Any, Section]]:
                 except IndexError:
                     add_match(directive, i, j, groups)
                     break
-                if block_line.lstrip() and _get_indentation(block_line) <= indentation:
+                if (
+                    syntax is DirectiveSyntax.RST
+                    and block_line.lstrip()
+                    and _get_indentation(block_line) <= indentation
+                ) or (syntax is DirectiveSyntax.MYST and block_line.lstrip() == "```"):
                     add_match(directive, i, j, groups)
                     i = j - 1
                     break
@@ -274,7 +305,9 @@ def get_sections(docstring: str) -> List[Union[Any, Section]]:
 
 
 def docstring2examples(
-    docstring: str, globs: Optional[GlobDict] = None
+    docstring: str,
+    syntax: DirectiveSyntax = DirectiveSyntax.RST,
+    globs: Optional[GlobDict] = None,
 ) -> List[Union[Any, doctest.Example]]:
     """
     Parse all sphinx test directives in the docstring and create a
@@ -285,7 +318,7 @@ def docstring2examples(
     if globs is None:
         globs = {}
 
-    sections = get_sections(docstring)
+    sections = get_sections(docstring, syntax)
 
     def get_testoutput_section_data(
         section: "Section",
@@ -532,6 +565,7 @@ class SphinxDoctestTextfile(pytest.Module):
         encoding = self.config.getini("doctest_encoding")
         text = self.fspath.read_text(encoding)
         name = self.fspath.basename
+        file_extension = Path(self.fspath).suffix
 
         optionflags = _pytest.doctest.get_optionflags(self)  # type:ignore
         runner = SphinxDocTestRunner(
@@ -540,8 +574,11 @@ class SphinxDoctestTextfile(pytest.Module):
             checker=_pytest.doctest._get_checker(),
         )
 
+        syntax = _FILE_EXTENSION_TO_SYNTAX[file_extension]
+        examples = docstring2examples(text, syntax=syntax)
+
         test = doctest.DocTest(
-            examples=docstring2examples(text),
+            examples=examples,
             globs={},
             name=name,
             filename=name,

--- a/src/pytest_sphinx.py
+++ b/src/pytest_sphinx.py
@@ -433,10 +433,6 @@ class SphinxDocTestRunner(doctest.DebugRunner):
                     else:
                         self.optionflags &= ~optionflag
 
-            # If 'SKIP' is set, then skip this example.
-            if self.optionflags & doctest.SKIP:
-                continue
-
             # Record that we started this example.
             tries += 1
             if not quiet:
@@ -471,9 +467,17 @@ class SphinxDocTestRunner(doctest.DebugRunner):
             # If the example executed without raising any exceptions,
             # verify its output.
             if exception is None:
-                # If 'MOCK' is set, then don't check the output.
-                if self.optionflags & _MOCK:
+                # If 'SKIP' is set, run the example code but don't check the
+                # output. This is different than upstream `pytest-sphinx`, which skips
+                # the example entirely.
+                if self.optionflags & doctest.SKIP:
                     outcome = SUCCESS
+
+                # 'MOCK' is deprecated in favor of 'SKIP'. Here for backwards
+                # compatibility.
+                elif self.optionflags & _MOCK:
+                    outcome = SUCCESS
+
                 elif check(example.want, got, self.optionflags):
                     outcome = SUCCESS
 

--- a/src/pytest_sphinx.py
+++ b/src/pytest_sphinx.py
@@ -433,6 +433,10 @@ class SphinxDocTestRunner(doctest.DebugRunner):
                     else:
                         self.optionflags &= ~optionflag
 
+            # If 'SKIP' is set, then skip this example.
+            if self.optionflags & doctest.SKIP:
+                continue
+
             # Record that we started this example.
             tries += 1
             if not quiet:
@@ -467,17 +471,9 @@ class SphinxDocTestRunner(doctest.DebugRunner):
             # If the example executed without raising any exceptions,
             # verify its output.
             if exception is None:
-                # If 'SKIP' is set, run the example code but don't check the
-                # output. This is different than upstream `pytest-sphinx`, which skips
-                # the example entirely.
-                if self.optionflags & doctest.SKIP:
+                # If 'MOCK' is set, then don't check the output.
+                if self.optionflags & _MOCK:
                     outcome = SUCCESS
-
-                # 'MOCK' is deprecated in favor of 'SKIP'. Here for backwards
-                # compatibility.
-                elif self.optionflags & _MOCK:
-                    outcome = SUCCESS
-
                 elif check(example.want, got, self.optionflags):
                     outcome = SUCCESS
 

--- a/tests/test_text_files.py
+++ b/tests/test_text_files.py
@@ -161,6 +161,41 @@ def test_no_ellipsis_in_global_optionflags(testdir: Testdir) -> None:
     )
 
 
+def test_successful_mock(testdir: Testdir) -> None:
+    testdir.maketxtfile(
+        test_something="""
+        .. testcode::
+
+            print('spam')
+
+        .. testoutput::
+            :options: +MOCK
+
+            NOT EVALUATED
+    """
+    )
+
+    result = testdir.runpytest()
+    result.stdout.fnmatch_lines(["*=== 1 passed in *"])
+
+
+def test_failing_mock(testdir: Testdir) -> None:
+    testdir.maketxtfile(
+        test_something="""
+        .. testcode::
+
+            assert False
+
+        .. testoutput::
+            :options: +MOCK
+
+            NOT EVALUATED
+    """
+    )
+
+    result = testdir.runpytest()
+    result.stdout.fnmatch_lines(["*=== 1 failed in *"])
+
 def test_skipif_non_builtin(testdir: Testdir) -> None:
     testdir.maketxtfile(
         test_something="""


### PR DESCRIPTION
There's an easier way to avoid the error that #3 solves, so I'm reverting the change. See https://github.com/ray-project/ray/pull/36359.