### PR TITLE
bump required pytest to 8.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 
 # Requirements
 dependencies = [
-    "pytest >=8.0.0",
+    "pytest >=8.1.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR bumps the required pytest version to 8.1.1.

Fixes #63 